### PR TITLE
#11: Add API endpoint to list monitored sites

### DIFF
--- a/cmd/monitor/main.go
+++ b/cmd/monitor/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -10,6 +11,9 @@ import (
 	"time"
 
 	"site-monitor/internal/config"
+	"site-monitor/internal/domain"
+	"site-monitor/internal/http/handler"
+	"site-monitor/internal/repository/memory"
 	"site-monitor/internal/scheduler"
 	"site-monitor/internal/server"
 )
@@ -29,22 +33,49 @@ func main() {
 		os.Exit(1)
 	}
 
-	handler := slog.NewJSONHandler(os.Stdout, nil)
-	logger := slog.New(handler)
+	// logger
+	handlerJSON := slog.NewJSONHandler(os.Stdout, nil)
+	logger := slog.New(handlerJSON)
 
 	logger.Info("Site Monitor started",
 		slog.Int("num_sites", len(cfg.Sites)),
 		slog.String("interval", cfg.Interval.String()),
 	)
 
+	// =========================
+	// MAP config.Site -> domain.Site
+	// =========================
+	sites := make([]domain.Site, 0, len(cfg.Sites))
+	for i, s := range cfg.Sites {
+		sites = append(sites, domain.Site{
+			ID:   fmt.Sprintf("site-%d", i+1),
+			Name: s.Name,
+			URL:  s.URL,
+		})
+	}
+
+	// =========================
+	// Repository + Handler (DI)
+	// =========================
+	siteRepo := memory.NewSiteMemoryRepository(sites)
+	siteHandler := handler.NewSiteHandler(siteRepo)
+
+	// =========================
+	// Scheduler (как было)
+	// =========================
 	s := scheduler.New(cfg.Interval, cfg.Sites, logger)
 	s.Start()
 
-	router := server.NewRouter()
+	// =========================
+	// HTTP server
+	// =========================
+	router := server.NewHTTPServer(siteHandler)
 	httpServer := server.New(":8080", router, logger)
 	httpServer.Start()
 
-	
+	// =========================
+	// Graceful shutdown
+	// =========================
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 	<-sigCh
@@ -55,11 +86,9 @@ func main() {
 	defer cancel()
 
 	if err := httpServer.Stop(ctx); err != nil {
-		logger.Error(
-			"failed to stop HTTP server",
-			slog.String("error", err.Error()),
-		)
+		logger.Error("failed to stop HTTP server", slog.String("error", err.Error()))
 	}
+
 	s.Stop()
 
 	logger.Info("Site Monitor stopped")

--- a/internal/domain/site.go
+++ b/internal/domain/site.go
@@ -1,0 +1,7 @@
+package domain
+
+type Site struct {
+	ID   string `json:"id"`
+	URL  string `json:"url"`
+	Name string `json:"name"`
+}

--- a/internal/http/handler/site_handler.go
+++ b/internal/http/handler/site_handler.go
@@ -1,0 +1,25 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"site-monitor/internal/repository"
+)
+
+type SiteHandler struct {
+	repo repository.SiteRepository
+}
+
+func NewSiteHandler(repo repository.SiteRepository) *SiteHandler {
+	return &SiteHandler{repo: repo}
+}
+
+func (h *SiteHandler) GetSites(w http.ResponseWriter, r *http.Request) {
+	sites := h.repo.GetAll()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	_ = json.NewEncoder(w).Encode(sites)
+}

--- a/internal/repository/memory/site_memory.go
+++ b/internal/repository/memory/site_memory.go
@@ -1,0 +1,29 @@
+package memory
+
+import (
+	"sync"
+
+	"site-monitor/internal/domain"
+)
+
+type SiteMemoryRepository struct {
+	mu    sync.RWMutex
+	sites []domain.Site
+}
+
+func NewSiteMemoryRepository(initial []domain.Site) *SiteMemoryRepository {
+	return &SiteMemoryRepository{
+		sites: initial,
+	}
+}
+
+func (r *SiteMemoryRepository) GetAll() []domain.Site {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	// важно: возвращаем копию, а не оригинальный slice
+	result := make([]domain.Site, len(r.sites))
+	copy(result, r.sites)
+
+	return result
+}

--- a/internal/repository/site_repository.go
+++ b/internal/repository/site_repository.go
@@ -1,0 +1,7 @@
+package repository
+
+import "site-monitor/internal/domain"
+
+type SiteRepository interface {
+	GetAll() []domain.Site
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	
+	"site-monitor/internal/http/handler"
 )
 
 type Server struct {
@@ -36,4 +38,12 @@ func (s *Server) Start() error {
 func (s *Server) Stop(ctx context.Context) error {
 	s.logger.Info("Stopping HTTP server...")
 	return s.httpServer.Shutdown(ctx)
+}
+
+func NewHTTPServer(siteHandler *handler.SiteHandler) *http.ServeMux {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/api/v1/sites", siteHandler.GetSites)
+
+	return mux
 }


### PR DESCRIPTION
- add Site domain model
- implement thread-safe in-memory site repository
- add site handler with dependency injection
- register GET /api/v1/sites endpoint
- initialize sites from config